### PR TITLE
Fix example int8_inference_huggingface.py

### DIFF
--- a/examples/int8_inference_huggingface.py
+++ b/examples/int8_inference_huggingface.py
@@ -1,27 +1,24 @@
 import torch
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import LlamaForCausalLM, LlamaTokenizer
 
 MAX_NEW_TOKENS = 128
 model_name = 'decapoda-research/llama-7b-hf'
 
 text = 'Hamburg is in which country?\n'
-tokenizer = AutoTokenizer.from_pretrained(model_name)
+tokenizer = LlamaTokenizer.from_pretrained(model_name)
 input_ids = tokenizer(text, return_tensors="pt").input_ids
 
-free_in_GB = int(torch.cuda.mem_get_info()[0]/1024**3)
 max_memory = f'{int(torch.cuda.mem_get_info()[0]/1024**3)-2}GB'
 
 n_gpus = torch.cuda.device_count()
 max_memory = {i: max_memory for i in range(n_gpus)}
 
-model = AutoModelForCausalLM.from_pretrained(
+model = LlamaForCausalLM.from_pretrained(
   model_name,
   device_map='auto',
   load_in_8bit=True,
   max_memory=max_memory
 )
+
 generated_ids = model.generate(input_ids, max_length=MAX_NEW_TOKENS)
 print(tokenizer.decode(generated_ids[0], skip_special_tokens=True))
-
-
-

--- a/examples/int8_inference_huggingface.py
+++ b/examples/int8_inference_huggingface.py
@@ -2,7 +2,7 @@ import torch
 from transformers import LlamaForCausalLM, LlamaTokenizer
 
 MAX_NEW_TOKENS = 128
-model_name = 'decapoda-research/llama-7b-hf'
+model_name = 'meta-llama/Llama-2-7b-hf'
 
 text = 'Hamburg is in which country?\n'
 tokenizer = LlamaTokenizer.from_pretrained(model_name)


### PR DESCRIPTION
### What
When running the example `int8_inference_huggingface.py`  I was getting the error:

```
ValueError: Tokenizer class LLaMATokenizer does not exist or is not currently imported
```

when using the latest transformers=4.29.2. According to [this issue](https://github.com/huggingface/transformers/issues/22222):

> the tokenizer in the [config on the hub](https://huggingface.co/decapoda-research/llama-7b-hf/blob/main/tokenizer_config.json) points to LLaMATokenizer. However, the tokenizer in the library is LlamaTokenizer.
This is likely due to the configuration files being created before the final PR was merged in.

([See comment](https://github.com/huggingface/transformers/issues/22222#issuecomment-1473423183))

### Fix
Use `LlamaForCausalLM` and  `LlamaTokenizer` instead of `Auto...` classes works as expected.


### Test plan
- Run `python examples/int8_inference_huggingface.py`
- Obtained the following output:
```txt
Hamburg is in which country?
The capital of Germany is Berlin.
The capital of Germany is Berlin.
The capital of Germany is Berlin.
The capital of Germany is Berlin.
The capital of Germany is Berlin.
The capital of Germany is Berlin.
The capital of Germany is Berlin.
The capital of Germany is Berlin.
The capital of Germany is Berlin.
The capital of Germany is Berlin.
The capital of Germany is Berlin.
The capital of Germany is Berlin.
The capital of Germany is Berlin.
The capital of Germany is Berlin.
The capital of Germany is Berlin.
```
